### PR TITLE
exclude files specific to nvhpc when using other compilers

### DIFF
--- a/src/fiat/CMakeLists.txt
+++ b/src/fiat/CMakeLists.txt
@@ -44,6 +44,12 @@ endif()
 configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/library/version.c.in ${CMAKE_CURRENT_BINARY_DIR}/version.c @ONLY )
 
 ecbuild_list_add_pattern( LIST fiat_src GLOB *.c *.F* *.cc )
+if(NOT (CMAKE_C_COMPILER_ID STREQUAL "PGI" OR CMAKE_C_COMPILER_ID STREQUAL "NVHPC" ))
+	# The files in the mynvtx directory are only intended to work with NVHPC
+	#	So don't try to compile them when using another compiler
+	ecbuild_list_exclude_pattern( LIST fiat_src REGEX mynvtx/* )
+endif()
+
 set( fiat_src ${fiat_src} PARENT_SCOPE )
 
 ecbuild_add_library( TARGET fiat


### PR DESCRIPTION
exclude files specific to nvhpc when using other compilers